### PR TITLE
Added support for TraitType::Optional

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = git@github.com:Loki-Astari/ThorMaker.git
+	url = https://github.com/Loki-Astari/ThorMaker.git

--- a/src/Serialize/Serialize.tpp
+++ b/src/Serialize/Serialize.tpp
@@ -380,6 +380,19 @@ class SerializeMember<T, M, TraitType::Value>
             printer.addValue(object.*(memberInfo.second));
         }
 };
+template<typename T, typename M>
+class SerializeMember<T, M, TraitType::Optional>
+{
+    public:
+    SerializeMember(PrinterInterface& printer, T const& object, std::pair<char const*, M T::*> const& memberInfo)
+    {
+        if (object.*(memberInfo.second)) {
+            printer.addKey(memberInfo.first);
+            Serializer      serialzier(printer, false);
+            serialzier.print(*(object.*(memberInfo.second)));
+        }
+    }
+};
 
 template<typename T, typename M>
 SerializeMember<T, M> make_SerializeMember(PrinterInterface& printer, T const& object, std::pair<char const*, M T::*> const& memberInfo)

--- a/src/Serialize/Traits.h
+++ b/src/Serialize/Traits.h
@@ -179,7 +179,7 @@ namespace ThorsAnvil
     namespace Serialize
     {
 
-enum class TraitType {Invalid, Parent, Value, Map, Array, Enum, Optional};
+enum class TraitType {Invalid, Parent, Value, Map, Array, Enum, Optional, Dynamic};
 template<typename T>
 class Traits
 {

--- a/src/Serialize/Traits.h
+++ b/src/Serialize/Traits.h
@@ -179,7 +179,7 @@ namespace ThorsAnvil
     namespace Serialize
     {
 
-enum class TraitType {Invalid, Parent, Value, Map, Array, Enum};
+enum class TraitType {Invalid, Parent, Value, Map, Array, Enum, Optional};
 template<typename T>
 class Traits
 {


### PR DESCRIPTION
For some of my classes, I have member variables which may or may not be set.  In order to create cleaner JSON output I wanted to define these variables as boost::optional<T> and then only output them if they have been set.  To do so, I needed to add a new TraitType called Optional.  I then added a new SerializeMember which only would serialize if the variable had been set.

I added this code to my project to activate this for boost::optional.  I didn't do it in the ThorsSerializer code because I didn't want to add a new dependency:

```
namespace ThorsAnvil
{
    namespace Serialize
    {

        template<typename Value>
        class Traits<boost::optional<Value> >
        {
        public:
            static constexpr TraitType type = TraitType::Optional;
        };

}
}
```

I haven't written the deserializer yet because I only need the serializer for my project.

Thoughts?
